### PR TITLE
Add newline after each subtitle

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -16,6 +16,10 @@ module.exports = function() {
 
       if(!vttLine.trim()) return cb();
 
+      if (/^[0-9]+$/m.test(vttLine)) {
+        vttLine = '\r\n' + vttLine;
+      }
+
       cb(null, vttLine);
     
   };

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ module.exports = function () {
 
     if (!vttLine.trim()) return cb();
 
+    if (/^[0-9]+$/m.test(vttLine)) {
+      vttLine = '\r\n' + vttLine;
+    }
+
     cb(null, vttLine);
   };
 


### PR DESCRIPTION
Many SRT editors assume that a blank line indicates the end of each subtitle, otherwise they say that the file is not a valid SRT.

This PR provides this fix.